### PR TITLE
new version of modeller

### DIFF
--- a/pwchemModeller/constants.py
+++ b/pwchemModeller/constants.py
@@ -31,4 +31,4 @@ AA_LIST = ['ALA', 'ARG', 'ASN', 'ASP', 'CYS', 'GLN', 'GLU', 'GLY',
            'THR', 'TRP', 'TYR', 'VAL']
 
 # Package & conda env dictionaries
-MODELLER_DIC = {'name': 'modeller', 'version': '10.4', 'home': 'MODELLER_HOME'}
+MODELLER_DIC = {'name': 'modeller', 'version': '10.8', 'home': 'MODELLER_HOME'}


### PR DESCRIPTION
version 10.4 de modeller ya no se encuentra en la librería. Cambiado a última versión de modeller 10.8